### PR TITLE
Fast identify patch and branding name patch fix

### DIFF
--- a/DiscordClientProxy/ClientPatches/Branding/BrandingNamePatch.cs
+++ b/DiscordClientProxy/ClientPatches/Branding/BrandingNamePatch.cs
@@ -9,14 +9,14 @@ public class BrandingNamePatch : ClientPatch
     {
         if (!content.Contains("Discord")) return content;
         Console.WriteLine($"[ClientPatch:{GetType().Name}] Applying patch...");
-        content = content.Replace(" Discord ", " ${INSTANCE_NAME} ");
-        content = content.Replace("Discord ", "${INSTANCE_NAME} ");
-        content = content.Replace(" Discord", " ${INSTANCE_NAME}");
-        content = content.Replace("Discord Premium", "${INSTANCE_NAME} Premium");
-        content = content.Replace("Discord Nitro", "${INSTANCE_NAME} Premium");
-        content = content.Replace("Discord's", "${INSTANCE_NAME}'s");
+        content = content.Replace(" Discord ", $" {Configuration.Instance.InstanceName} ");
+        content = content.Replace("Discord ", $"{Configuration.Instance.InstanceName} ");
+        content = content.Replace(" Discord", $" {Configuration.Instance.InstanceName}");
+        content = content.Replace("Discord Premium", $"{Configuration.Instance.InstanceName} Premium");
+        content = content.Replace("Discord Nitro", $"{Configuration.Instance.InstanceName} Premium");
+        content = content.Replace("Discord's", $"{Configuration.Instance.InstanceName}'s");
         //content = content.Replace("DiscordTag", "FosscordTag");
-        content = content.Replace("*Discord*", "*${INSTANCE_NAME}*");
+        content = content.Replace("*Discord*", $"*{Configuration.Instance.InstanceName}*");
         return content;
     }
 }

--- a/DiscordClientProxy/ClientPatches/FastIdentifyPatch.cs
+++ b/DiscordClientProxy/ClientPatches/FastIdentifyPatch.cs
@@ -1,0 +1,14 @@
+﻿using DiscordClientProxy.Classes;
+
+namespace DiscordClientProxy.ClientPatches;
+
+public class FastIdentifyPatch : ClientPatch
+{
+    public override async Task<string> ApplyPatch(string content)
+    {
+        Console.WriteLine($"[ClientPatch:{GetType().Name}] Applying patch...");
+        content = content.Replace("e.isFastConnect=t;t?e._doFastConnectIdentify():e._doResumeOrIdentify()",
+            "e.isFastConnect=t; if (t !== undefined) e._doResumeOrIdentify();");
+        return content;
+    }
+}

--- a/DiscordClientProxy/Configuration.cs
+++ b/DiscordClientProxy/Configuration.cs
@@ -23,6 +23,7 @@ public class Configuration
 
     public string Version { get; set; } = "latest";
     public string AssetCacheLocation { get; set; } = "assets_cache/$VERSION/";
+    public string InstanceName { get; set; } = "Fosscord";
     
     public ClientOptions Client { get; set; } = new();
     public CacheOptions Cache { get; set; } = new();

--- a/DiscordClientProxy/Utilities/ClientPatcher.cs
+++ b/DiscordClientProxy/Utilities/ClientPatcher.cs
@@ -16,10 +16,11 @@ public class ClientPatcher
         new GatewayImmediateReconnectPatch(), // Remove reconnect delay in gateway
         new KeepLocalStoragePatch(), // Prevent client from clearing localStorage 
         new NoQrLoginPatch(), // Remove QR login
+        new FastIdentifyPatch(),
         //branding
         new BrandingLogoPatch(),
         new BrandingPremiumPatch(),
-        //new BrandingNamePatch(), //FIXME: doesn't currently work
+        new BrandingNamePatch(),
         new BrandingGuildReferencePatch(),
     };
 
@@ -45,7 +46,7 @@ public class ClientPatcher
     {
         foreach (var patch in ClientPatches)
         {
-            //make sure its definately in there!
+            //make sure its definitely in there!
             if (!Configuration.Instance.Client.DebugOptions.Patches.ContainsKey(patch.GetType().Name))
             {
                 Configuration.Instance.Client.DebugOptions.Patches.TryAdd(patch.GetType().Name, patch.IsEnabledByDefault);


### PR DESCRIPTION
Fast identify may not work due to how you load GLOBAL_ENV from an endpoint. GLOBAL_ENV *must* be available for fast identify to work. Locally I just copied the proper env into the index.html file, so I don't know though.